### PR TITLE
12. Adicionar Contagem de Caracteres em Textarea

### DIFF
--- a/my-react-app/src/pages/Doubt/doubt.jsx
+++ b/my-react-app/src/pages/Doubt/doubt.jsx
@@ -1,4 +1,4 @@
-import './doubt.module.css'
+import './Doubt.Module.css'
 import React, { useState } from 'react';
 
 const DoubtsButton = ({ doubtsButtonText, image, activeText }) => {
@@ -107,15 +107,16 @@ function Doubts() {
               required
             />
           </div>
-          <div className="form-row">
-            <textarea
-              id="mensagem"
-              name="mensagem"
-              placeholder="Mensagem"
-              value={formData.mensagem}
-              onChange={handleChange}
-              required
-            ></textarea>
+            <div className='form-row'>
+              <textarea 
+                id='mensagem'
+                name='mensagem'
+                placeholder='Mensagem'
+                value={formData.mensagem}
+                onChange={handleChange}
+                maxLength={200}
+              ></textarea>
+              <p>{formData.mensagem.length}/200</p>
           </div>
           <div className="button-container">
             <button type="submit" className="submit-button">Enviar</button>

--- a/my-react-app/src/pages/Doubt/doubt.module.css
+++ b/my-react-app/src/pages/Doubt/doubt.module.css
@@ -134,6 +134,13 @@
     padding: auto;
 }
 
+.form-row p {
+    font-size: 14px;
+    color: #666;
+    margin-top: 5px;
+    align-self: flex-end;
+}
+
 /* Responsividade */
 @media (max-width: 768px) {
     .titulocontato {


### PR DESCRIPTION
## Commit (https://github.com/joaoveasey/projeto-fatec-react/commit/2739661326dd77d97a13786198204eb20ee94361)

- [ ] 12. Adicionar Contagem de Caracteres em Textarea
<br>

![image](https://github.com/joaoveasey/projeto-fatec-react/assets/125090850/859bbc91-f655-4d77-97da-e54bfcec1352)

### Explicação da implementação acordo com UX/UI e IHC:
- Feedback ao Usuário: O contador de caracteres abaixo da área de texto fornece feedback contínuo ao usuário sobre quantos caracteres foram digitados e quantos ainda podem ser digitados, evitando frustrações.
- Estética Minimalista: O design simples e limpo com bordas suaves e um espaço adequado ao redor do texto ajuda a manter a interface descomplicada e fácil de usar, melhorando a experiência do usuário.